### PR TITLE
Add aws-policy-minimize.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A set of tools to simplify the usage of AWS
               created session.
  - `aws-s3-tree`: A tool to query S3 buckets in a user-friendly way.
 
+ - `aws-policy-minimize`: A tool to find a minimal AWS policy that will allow some actions.
+
 ## Getting started
 
 Install the dependencies:
@@ -18,3 +20,46 @@ pip3 install -r requirements.txt
 ```
 
 Then run the commands directly from the `bin/` directory.
+
+
+
+#### aws-policy-minimize
+
+   `aws-policy-minimize [options] <testscript> <maxperm.json> <policyARN> -o <minperm.json>`
+
+
+This tool allows you to minimize an AWS policy.
+
+You need to supply `maxperm.json` containing a policy to minimize. aws-policy-minimize will
+subtract permissions until it finds a minimal subset.
+
+To use:
+  * You need to first set up a policy attached to the things you want to test. This WILL BE OVERWRITTEN.
+  * You also need a json file containing a policy that's known to work (IE, one that is very generous).
+    This must enumerate everything explicitly, not use wildcards.
+  * You also need a test script, which tries all the things you want the policy to allow. It must yield
+    a return code of zero if it succeeeds, otherwise any other code. (DD libraries also allow  a third
+    'invalid coniguration' code, but since we should aloways generate a syntactically correct policy, 
+     we don't use that).
+  * If you need to use different AWS credentials for the test to the ones needed for uploading the
+    policy, place these in AWS variables starting TEST_, eg TEST_AWS_ACCESS_KEY_ID.
+
+Limitations:
+  
+
+  Currently assumes the use of environment variables to pass in the AWS credentials, not any other mechanism.
+
+  Relies on a timeout after uploading  the policy. This seems to need to be 30secs, which
+    makes the process a bit slow. As this is based on trial and error, it may turn out that
+    it is not enough.  If the results of the test are therefore inconsistent, we get an assertion
+    failure from picire, which isn't very useful in producing a good error message. Indeed,
+    error messages are not great yet anywhere.
+
+  Always sets the policy version to be the default, so don't use it on a live policy that
+    is being used for other things.
+
+  The library (picire) we use for minimization seens to have a bug in that it sometimes restests
+   a configuration which it already tried (it's supposed to cache answers, but apparently doesn't)
+
+  It doesn't know about '*' so you need to specify all the individual actions/resources.
+

--- a/aws-policy-minimize/examples/maxS3Perm.json
+++ b/aws-policy-minimize/examples/maxS3Perm.json
@@ -1,0 +1,48 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetLifecycleConfiguration",
+                "s3:ListBucketByTags",
+                "s3:GetBucketTagging",
+                "s3:GetInventoryConfiguration",
+                "s3:DeleteObjectVersion",
+                "s3:GetObjectVersionTagging",
+                "s3:GetBucketLogging",
+                "s3:ListBucketVersions",
+                "s3:GetAccelerateConfiguration",
+                "s3:ListBucket",
+                "s3:GetBucketPolicy",
+                "s3:GetEncryptionConfiguration",
+                "s3:GetObjectAcl",
+                "s3:GetObjectVersionTorrent",
+                "s3:GetBucketRequestPayment",
+                "s3:GetObjectVersionAcl",
+                "s3:GetObjectTagging",
+                "s3:GetMetricsConfiguration",
+                "s3:DeleteObject",
+                "s3:GetBucketPolicyStatus",
+                "s3:GetBucketPublicAccessBlock",
+                "s3:ListBucketMultipartUploads",
+                "s3:GetBucketWebsite",
+                "s3:GetBucketVersioning",
+                "s3:GetBucketAcl",
+                "s3:GetBucketNotification",
+                "s3:GetReplicationConfiguration",
+                "s3:ListMultipartUploadParts",
+                "s3:GetObject",
+                "s3:GetObjectTorrent",
+                "s3:DescribeJob",
+                "s3:GetBucketCORS",
+                "s3:GetAnalyticsConfiguration",
+                "s3:GetObjectVersionForReplication",
+                "s3:GetBucketLocation",
+                "s3:GetObjectVersion"
+            ],
+            "Resource": "arn:aws:s3:::sample-bucket-name"
+        }
+    ]
+}

--- a/aws-policy-minimize/examples/testScriptS3
+++ b/aws-policy-minimize/examples/testScriptS3
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+"""
+An example script to test aws-policy-minimize. It tries to list a bucket.
+"""
+
+import boto3
+
+testBucket = 'sample-bucket-name'
+
+s3 = boto3.resource('s3')
+bucket = s3.Bucket(testBucket)
+objects = [x for x in bucket.objects.all()]
+

--- a/bin/aws-policy-minimize
+++ b/bin/aws-policy-minimize
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+
+
+'''
+A tool to find a minimal permission set
+
+Usage:
+    aws-policy-minimize [options] <testscript> <maxperm.json> <policyARN> -o <minperm.json>
+
+Options:
+    --verbose,-v                      Print trials
+    --sleeptime SLEEP, -s SLEEP       sleep time  [default: 30]
+
+Arguments:
+    testscript             A script which needs the permissions
+    maxperm.json           An aws policy json. Note that statement IDs must be unique
+    policyARN              ARN to load the test policy into. 
+    minperm.json           Where to write the minimal policy locally.
+
+
+Environment variables:
+
+    AWS_ACCESS_KEY_ID      Will be used for SETTING the permissions
+    AWS_SECRET_ACCESS_KEY   ..
+    AWS_SESSION_TOKEN       ..
+
+    TEST_AWS_ACCESS_KEY_ID      If set, we are going to pass these as
+    TEST_AWS_SECRET_ACCESS_KEY   aws credentials to the test script
+    TEST_AWS_SESSION_TOKEN       Ie, for USING the permissions
+
+
+'''
+
+
+import boto3
+import docopt
+import json
+import sys
+import itertools
+import picire
+import os
+import subprocess
+import time
+
+
+
+class UnsupportedEffect(Exception):
+    def __init__(self, effect):
+        self.effect = effect
+
+    def __str__(self):
+        return "unsupported effect %s" % (self.effect)
+
+
+def elimSingleton(items):
+    if type(items) != list:
+        return [items]
+    return items
+
+def makeSingleton(items):
+    if len(items)==1:
+        return items[0]
+    return items
+    
+
+class AWSPolicyStatement:
+    def __init__(self, jsonFrag):
+        if jsonFrag['Effect'] != 'Allow':
+            raise UnsupportedEffect(jsonFrag['Effect'])
+
+        self.origJson = jsonFrag
+
+        self.actions = elimSingleton(jsonFrag['Action'])
+        self.resources = elimSingleton(jsonFrag['Resource'])
+        self.idStr = jsonFrag['Sid']
+
+    def _actionId(self,action):
+        return "%s/action/%s" % (self.idStr, action)
+
+    def _resourceId(self,resource):
+        return "%s/resource/%s" % (self.idStr, resource)
+
+    def statementPartIDs(self):
+        return [self._actionId(a) for a in self.actions] + [self._resourceId(r) for r in self.resources]
+
+    def makeStatementSubset(self, statementPartIDs):
+        res = self.origJson.copy()
+        actions = [a for a in self.actions if self._actionId(a) in statementPartIDs]
+        if not len(actions):
+            return None
+
+        resources = [r for r in self.resources if self._resourceId(r) in statementPartIDs]
+        if not len(resources):
+            return None
+
+        res['Action'] = actions
+        res['Resource'] = resources
+        return res
+        
+
+class AWSPolicyGen:
+    """
+    This class parses a policy json file, and allows us to generate subsets of it.
+
+    """
+    def __init__(self, policyFile):
+        self.policyFile = json.loads(open(policyFile, 'r').read())
+        self.statements = [AWSPolicyStatement(s) for s in
+                           self.policyFile['Statement']]
+        self.configIDs = list(itertools.chain(*[x.statementPartIDs() for x in
+                                               self.statements]))
+        
+
+    def policyPartIDs(self):
+        """
+        Return a list of identifiers for things that can be removed from the policy
+        """
+        return self.configIDs
+        
+    def makePolicySubset(self, statementPartIDs):
+        """
+        Based on a subset of the policy identifiers, 
+        """
+        res = self.policyFile.copy()
+
+        statements = []
+        for s in self.statements:
+            smod = s.makeStatementSubset(statementPartIDs)
+            if smod:
+                statements.append(smod)
+        res['Statement'] = statements
+        return res
+
+class AWSPolicyTester():
+    """
+    Integration class. picire wants a test function,
+    but can't pass it any arguments, so we collect everything we need in this
+    class, but avoid doing much logic here.
+    """
+    
+    def __init__(self, policyGen, policyLoader, scriptRunner, verbose):
+        self.scriptRunner = scriptRunner
+        self.policyLoader = policyLoader
+        self.verbose = verbose
+        self.policyGen = policyGen
+
+    def test(self, policyPartIDs, config_ID):
+        if self.verbose:
+            print("Trying: ",policyPartIDs)
+        policy = self.policyGen.makePolicySubset(policyPartIDs)
+
+        # a policy needs at least one statement
+        if policy['Statement'] ==[]:
+            return picire.AbstractDD.PASS
+
+
+        self.policyLoader.load(policy)
+
+        retval = self.scriptRunner.run()
+
+
+        # picire looks for the minimal 'failing' config.
+        # but we want to look for the minimum successful config
+        # so we need to invert the return value
+        if retval == 0:
+            if self.verbose:
+                print("Succeeded\n")
+            return picire.AbstractDD.FAIL
+        if self.verbose:
+            print("Failed")
+        return picire.AbstractDD.PASS
+
+class PolicyLoader:
+    """
+    class to load a policy into a particilar policy ARN in AWS
+    Currently assumes the policy already exists, and we want to overwrite it.
+    We can only create versions of a policy, so we need to potentially
+    delete a version (if we have too many)
+    """
+
+    aws_max_policies = 5
+
+    def __init__(self, arn, sleepTime):
+        self.arn = arn
+        self.sleepTime = sleepTime
+        iam = boto3.resource('iam')
+        self.policy = iam.Policy(self.arn)
+
+    def load(self, policy):
+        # FIXME more error handling 
+        versions = [v for v in self.policy.versions.all()]
+        versions.sort(key=lambda x: x.version_id)
+
+        if len(versions) >= self.aws_max_policies:
+            if versions[0].is_default_version:
+                versions[1].delete()
+            else:
+                versions[0].delete()
+
+        policy_version = self.policy.create_version(PolicyDocument = json.dumps(policy),
+                                                    SetAsDefault=True)
+        time.sleep(self.sleepTime)
+
+
+class ScriptRunner:
+    """
+    Run the test script, and pass any environment variables
+    """
+
+    copyVars = ["AWS_ACCESS_KEY_ID","AWS_SECRET_ACCESS_KEY","AWS_SESSION_TOKEN"]
+    
+    def __init__(self, testScript):
+        self.testScript = testScript
+        self.environ = os.environ.copy()
+        for var in self.copyVars:
+            testVar = 'TEST_'+var
+            if testVar in self.environ:
+                self.environ[var] = self.environ[testVar]
+
+    def run(self):
+        return subprocess.run([self.testScript], env=self.environ).returncode
+
+
+def main(args):
+    testScript = args.get('<testscript>')
+    maxPerm = args.get('<maxperm.json>')
+    policyARN = args.get('<policyARN>')
+    minPerm = args.get('<minperm.json>')
+    minPermFile = open(minPerm, 'w') # open at the start to fail early
+
+    sleepTime = int(args.get('--sleeptime'))
+
+    policyLoader = PolicyLoader(policyARN, sleepTime)
+    scriptRunner = ScriptRunner(testScript)
+    
+    try:
+        policyGen = AWSPolicyGen(maxPerm)
+        policyTester = AWSPolicyTester(policyGen, policyLoader, scriptRunner, args['--verbose'])
+    except Exception as e:
+        print("Unable to load policy file", e)
+        sys.exit(1)
+
+    policyPartIDs = policyGen.policyPartIDs()
+
+    dd = picire.LightDD(test=policyTester.test)
+
+    minConfig = dd.ddmin(policyPartIDs)
+
+    minConfigStr = json.dumps(policyGen.makePolicySubset(minConfig))
+    minPermFile.write(minConfigStr)
+    minPermFile.close()
+    
+    
+
+if __name__ == '__main__':
+    ARGS = docopt.docopt(__doc__)
+    sys.exit(main(ARGS))
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ boto3
 docopt
 jsonschema
 pyyaml
+picire
+


### PR DESCRIPTION
This adds a script aws-policy-minimize which finds a minimal AWS policy which allows some action.
At the moment it's all in one file, later maybe it's worth making it into a package.


It uses the module picire for the delta-debugging logic. TBH I don't know how robust picire is, it has asserts in it which isn't ideal. I chose it mainly because it's in pypi, and the original [DD.py](https://www.st.cs.uni-saarland.de/dd/DD.py) isn't.