### PR TITLE
Add profiles and  roles, subshell

### DIFF
--- a/bin/aws-mfa
+++ b/bin/aws-mfa
@@ -8,12 +8,14 @@ created session.
 Can also assume a role.
 
 Usage:
-    aws-mfa [--profile <profile>] login [--duration=<time>] <mfa_token> [--shell]
-    aws-mfa [--profile <profile>] set-mfa-arn <mfa_arn>
-    aws-mfa [--profile <profile>] add-role <nickname> <role_arn>
-    aws-mfa [--profile <profile>] assume-role <nickname>  [--shell]
+    aws-mfa [--profile=<profile>] login [--duration=<time>] <mfa_token> [--shell]
+    aws-mfa [--profile=<profile>] set-mfa-arn <mfa_arn>
+    aws-mfa [--profile=<profile>] add-role <nickname> <role_arn>
+    aws-mfa [--profile=<profile>] assume-role <nickname>  [--duration=<time>] [--shell]
+
 
 Arguments:
+    --profile=<profile>              Use this profile from your aws config.
     login                            Create an AWS session with a MFA token
     set-mfa-arn                      Configure an ARN to use as the MFA device
     --duration=<time>, -d <time>     How long to create the session for
@@ -39,33 +41,43 @@ CONFIG_FILE = os.path.join(
     os.path.expanduser('~'), '.aws-mfa-login'
 )
 DEFAULT_CONFIG = {
-    'mfa_arn': '',
+    'version': 2,
     'profiles': {}
 }
 
-CONFIG_SCHEMA = {
-    'definitions': {
-      'account':  {
+CONFIG_SCHEMA_VERSIONS = {
+    1: {
         'type': 'object',
         'properties': {
-            'mfa_arn': {'type': 'string'},
-            'role_map': {
-                'type': 'object',
-                'additionalProperties': {'type': 'string'}
-            }
+            'mfa_arn': {'type': 'string'}
         }
-      },
-      'role_map':  { "$ref": "#/definitions/role_map" }
     },
-    'type': 'object',
-    'properties': {
-        'mfa_arn': {'type': 'string'}, # default mfa
-        'profiles' : {
-           'type': 'object',
-           'additionalProperties': { "$ref": "#/definitions/account" }
+
+    2: {
+        'definitions': {
+            'account':  {
+                'type': 'object',
+                'properties': {
+                    'mfa_arn': {'type': 'string'},
+                    'role_map': {
+                        'type': 'object',
+                        'additionalProperties': {'type': 'string'}
+                    }
+                }
+            },
         },
-        'role_map':  { "$ref": "#/definitions/role_map" }
-   }
+        'type': 'object',
+        'properties': {
+            'version': {
+                'type' : 'integer'
+            },
+            'profiles' : {
+                'type': 'object',
+                'additionalProperties': { "$ref": "#/definitions/account" }
+            },
+        },
+        'required': ['profiles', 'version']
+    }
 }
 
 class EnvManager:
@@ -115,6 +127,7 @@ class EnvManager:
         env['AWS_ACCESS_KEY_ID'] = access_key_id
         env['AWS_SECRET_ACCESS_KEY'] = secret_access_key
         env['AWS_SESSION_TOKEN'] = session_token
+        env['AWS_SESSION_NAME'] = sessionName
 
         shellCmdArgs, promptVar = self._get_shell()
         if promptVar in env:
@@ -129,6 +142,8 @@ class AccountManager:
 
     def __init__(self, profile):
         self.profile = profile
+        self.config_version = 1
+        self.max_config_version = len(CONFIG_SCHEMA_VERSIONS)
 
 
     @contextmanager
@@ -140,6 +155,19 @@ class AccountManager:
             self.store_config(conf)
 
 
+    def migrate_config(self, conf):
+        while self.config_version < self.max_config_version:
+            if self.config_version == 1:
+                conf = {
+                    'version': 2,
+                    'profiles': {
+                        'default':
+                           conf
+                        }
+                    }
+            self.config_version +=1
+            return conf
+
     def get_config(self):
         conf = None
 
@@ -150,13 +178,19 @@ class AccountManager:
         if not conf:
             conf = DEFAULT_CONFIG
 
-        jsonschema.validate(conf, CONFIG_SCHEMA)
+        if 'version' not in conf or conf['version'] < self.max_config_version:
+            conf = self.migrate_config(conf)
+            self.store_config(conf)
+        else:
+            self.config_version = conf['version']
+
+        jsonschema.validate(conf, CONFIG_SCHEMA_VERSIONS[self.config_version])
 
         return conf
 
 
     def store_config(self, conf):
-        jsonschema.validate(conf, CONFIG_SCHEMA)
+        jsonschema.validate(conf, CONFIG_SCHEMA_VERSIONS[self.config_version])
 
         with open(CONFIG_FILE, 'w') as conf_f:
             yaml.dump(conf, conf_f)
@@ -176,35 +210,27 @@ class AccountManager:
 
     def get_mfa_arn(self):
         conf = self.get_config()
-        if self.profile != 'default':
-            if self.profile in conf['profiles']:
-                return conf['profiles'][self.profile]['mfa_arn']
-            else:
-                print('missing ARN for profile ', self.profile)
-        return conf['mfa_arn']
+        if self.profile in conf['profiles']:
+            return conf['profiles'][self.profile]['mfa_arn']
+        return None
 
     def set_role_arn(self, nickname, arn):
         with self.persistConfig() as conf:
-           if self.profile != 'default':
-               if not 'profiles'  in conf:
-                   conf['profiles'] = {}
-               if self.profile not in conf['profiles']:
-                   conf['profiles'][self.profile] = {}
-               if 'role_map' not in conf['profiles'][self.profile]:
-                   conf['profiles'][self.profile]['role_map'] = {}
-               conf['profiles'][self.profile]['role_map'][nickname] = arn
-           else:
-               conf['role_map'][nickname] = arn
+            if not 'profiles'  in conf:
+                conf['profiles'] = {}
+            if self.profile not in conf['profiles']:
+                conf['profiles'][self.profile] = {}
+            if 'role_map' not in conf['profiles'][self.profile]:
+                conf['profiles'][self.profile]['role_map'] = {}
+            conf['profiles'][self.profile]['role_map'][nickname] = arn
 
     def get_role_arn(self, nickname):
         conf = self.get_config()
         try:
-            if self.profile != 'default':
-                if self.profile in conf['profiles'] and nickname in  conf['profiles'][self.profile]['role_map']:
-                    return conf['profiles'][self.profile]['role_map'][nickname]
-                else:
-                    print('missing ARN for profile ', self.profile,' role ', nickname)
-            return conf['role_map'][nickname]
+            if self.profile in conf['profiles'] and nickname in  conf['profiles'][self.profile]['role_map']:
+                return conf['profiles'][self.profile]['role_map'][nickname]
+            else:
+                return None
         except:
             return None
 
@@ -231,10 +257,20 @@ class AccountManager:
 
             return role_arn
 
+    def get_boto_session(self):
+        profile_name = self.profile
+        if 'AWS_SESSION_NAME' in os.environ or self.profile == 'default':
+            # if we are in a sesssion started by aws-mfa, we don't want to use the
+            # credentials from ~/.aws/cfredentials, because that drops the MFA token.
+            # So don't pass in a profile, which means we use the env vars.
+            session = boto3.Session()
+        else:
+           session = boto3.Session(profile_name=profile_name)
+        return session
+
 
     def get_session_keys(self, mfa_arn, mfa_token, duration):
-        if self.profile != 'default':
-           session = boto3.Session(profile_name=self.profile)
+        session = self.get_boto_session()
         aws_client = session.client('sts')
         return aws_client.get_session_token(
             DurationSeconds=duration,
@@ -243,8 +279,7 @@ class AccountManager:
         )
 
     def get_role_keys(self, role_arn, nickname,duration):
-        if self.profile != 'default':
-           session = boto3.Session(profile_name=self.profile)
+        session = self.get_boto_session()
         aws_client = session.client('sts')
         return aws_client.assume_role(
             RoleArn=role_arn,
@@ -258,7 +293,11 @@ class AccountManager:
 def main(args):
     profile = 'default'
     if args.get('--profile'):
-       profile = args.get('<profile>')
+        profile = args.get('--profile')
+    elif 'AWS_SESSION_NAME' in os.environ:
+        # if we are in a session started by aws-mfa, use that
+        profile = os.environ['AWS_SESSION_NAME']
+
     mgr = AccountManager(profile)
 
     if args.get('set-mfa-arn'):

--- a/bin/aws-mfa
+++ b/bin/aws-mfa
@@ -6,8 +6,8 @@ configuration file and providing a set of commands to run to utilise the
 created session.
 
 Usage:
-    aws-mfa login [--duration=<time>] <mfa_token>
-    aws-mfa set-mfa-arn <mfa_arn>
+    aws-mfa [--profile <profile>] login [--duration=<time>] <mfa_token>
+    aws-mfa [--profile <profile>] set-mfa-arn <mfa_arn>
 
 Arguments:
     login                            Create an AWS session with a MFA token
@@ -31,108 +31,142 @@ CONFIG_FILE = os.path.join(
     os.path.expanduser('~'), '.aws-mfa-login'
 )
 DEFAULT_CONFIG = {
-    'mfa_arn': ''
+    'mfa_arn': '',
+    'profiles': {}
 }
 
 CONFIG_SCHEMA = {
+    'definitions': {
+      'account':  {
+        'type': 'object',
+        'properties': {
+            'mfa_arn': {'type': 'string'}
+        }
+      }
+    },
     'type': 'object',
     'properties': {
-        'mfa_arn': {'type': 'string'}
-    }
+        'mfa_arn': {'type': 'string'}, # default mfa
+        'profiles' : {
+           'type': 'object',
+           'additionalProperties': { "$ref": "#/definitions/account" }
+        }
+   }
 }
 
+class AccountManager:
+    def __init__(self, profile):
+        self.profile = profile
 
-def get_config():
-    conf = None
+    def get_config(self):
+        conf = None
 
-    if os.path.exists(CONFIG_FILE):
-        with open(CONFIG_FILE, 'r') as conf_f:
-            conf = yaml.safe_load(conf_f)
+        if os.path.exists(CONFIG_FILE):
+            with open(CONFIG_FILE, 'r') as conf_f:
+                conf = yaml.safe_load(conf_f)
 
-    if not conf:
-        conf = DEFAULT_CONFIG
+        if not conf:
+            conf = DEFAULT_CONFIG
 
-    jsonschema.validate(conf, CONFIG_SCHEMA)
+        jsonschema.validate(conf, CONFIG_SCHEMA)
 
-    return conf
-
-
-def store_config(conf):
-    jsonschema.validate(conf, CONFIG_SCHEMA)
-
-    with open(CONFIG_FILE, 'w') as conf_f:
-        yaml.dump(conf, conf_f)
+        return conf
 
 
-def set_mfa_arn(arn):
-    conf = get_config()
-    conf['mfa_arn'] = arn
-    store_config(conf)
+    def store_config(self, conf):
+        jsonschema.validate(conf, CONFIG_SCHEMA)
+
+        with open(CONFIG_FILE, 'w') as conf_f:
+            yaml.dump(conf, conf_f)
 
 
-def get_mfa_arn():
-    conf = get_config()
-
-    return conf['mfa_arn']
-
-
-def ensure_mfa_arn():
-        mfa = get_mfa_arn()
-
-        if mfa:
-            return mfa
-
-        mfa_arn = input('What is your MFA ARN?: ')
-        set_mfa_arn(mfa_arn)
-
-        return mfa_arn
+    def set_mfa_arn(self, arn):
+        conf = self.get_config()
+        if self.profile != 'default':
+            if not 'profiles'  in conf:
+                conf['profiles'] = {}
+            if self.profile not in conf['profiles']:
+                conf['profiles'][self.profile] = {}
+            conf['profiles'][self.profile]['mfa_arn'] = arn
+        else:
+            conf['mfa_arn'] = arn
+        self.store_config(conf)
 
 
-def get_session_keys(mfa_arn, mfa_token, duration):
-    aws_client = boto3.client('sts')
-    return aws_client.get_session_token(
-        DurationSeconds=duration,
-        SerialNumber=mfa_arn,
-        TokenCode=mfa_token
-    )
+    def get_mfa_arn(self):
+        conf = self.get_config()
+        if self.profile != 'default':
+            if self.profile in conf['profiles']:
+                return conf['profiles'][self.profile]['mfa_arn']
+            else:
+                print('missing ARN for profile ', self.profile)
+        return conf['mfa_arn']
 
 
-def get_exports(keys):
-    creds = keys['Credentials']
-    access_key_id = creds['AccessKeyId']
-    secret_access_key = creds['SecretAccessKey']
-    session_token = creds['SessionToken']
-    expiration = creds['Expiration']
+    def ensure_mfa_arn(self):
+            mfa = self.get_mfa_arn()
 
-    print(textwrap.dedent('''
-        Paste the following into your terminal:
+            if mfa:
+                return mfa
 
-            export AWS_ACCESS_KEY_ID="{access}"
-            export AWS_SECRET_ACCESS_KEY="{secret}"
-            export AWS_SESSION_TOKEN="{token}"
+            mfa_arn = input('What is your MFA ARN?: ')
+            set_mfa_arn(mfa_arn)
 
-        These credentials will expire at {expire}.
-    '''.format(
-            access=access_key_id,
-            secret=secret_access_key,
-            token=session_token,
-            expire=expiration
+            return mfa_arn
+
+
+    def get_session_keys(self, mfa_arn, mfa_token, duration):
+        if self.profile != 'default':
+           session = boto3.Session(profile_name=self.profile)
+        aws_client = session.client('sts')
+        return aws_client.get_session_token(
+            DurationSeconds=duration,
+            SerialNumber=mfa_arn,
+            TokenCode=mfa_token
         )
-    ))
+
+
+    def get_exports(self, keys):
+        creds = keys['Credentials']
+        access_key_id = creds['AccessKeyId']
+        secret_access_key = creds['SecretAccessKey']
+        session_token = creds['SessionToken']
+        expiration = creds['Expiration']
+
+        print(textwrap.dedent('''
+            Paste the following into your terminal:
+
+                export AWS_ACCESS_KEY_ID="{access}"
+                export AWS_SECRET_ACCESS_KEY="{secret}"
+                export AWS_SESSION_TOKEN="{token}"
+    
+            These credentials will expire at {expire}.
+        '''.format(
+                access=access_key_id,
+                secret=secret_access_key,
+                token=session_token,
+                expire=expiration
+            )
+        ))
 
 
 def main(args):
+    profile = 'default'
+    if args.get('--profile'):
+       profile = args.get('<profile>')
+    mgr = AccountManager(profile)
+
     if args.get('set-mfa-arn'):
-        set_mfa_arn(args.get('<mfa_arn>'))
-        print('Set MFA ARN to {}'.format(get_config()['mfa_arn']))
+        mgr.set_mfa_arn(args.get('<mfa_arn>'))
+        print('Set MFA ARN for {} to {}'.format(profile, mgr.get_config()['mfa_arn']))
 
     if args.get('login'):
-        mfa_arn = ensure_mfa_arn()
+        mfa_arn = mgr.ensure_mfa_arn()
         mfa_token = args.get('<mfa_token>')
         duration = int(args.get('--duration'))
 
-        keys = get_session_keys(mfa_arn, mfa_token, duration)
-        get_exports(keys)
+        keys = mgr.get_session_keys(mfa_arn, mfa_token, duration)
+        mgr.get_exports(keys)
 
 
 if __name__ == '__main__':

--- a/bin/aws-mfa
+++ b/bin/aws-mfa
@@ -5,15 +5,20 @@ A tool to manage MFA session creation, allowing the settings to be saved to a
 configuration file and providing a set of commands to run to utilise the
 created session.
 
+Can also assume a role.
+
 Usage:
-    aws-mfa [--profile <profile>] login [--duration=<time>] <mfa_token>
+    aws-mfa [--profile <profile>] login [--duration=<time>] <mfa_token> [--shell]
     aws-mfa [--profile <profile>] set-mfa-arn <mfa_arn>
+    aws-mfa [--profile <profile>] add-role <nickname> <role_arn>
+    aws-mfa [--profile <profile>] assume-role <nickname>  [--shell]
 
 Arguments:
     login                            Create an AWS session with a MFA token
     set-mfa-arn                      Configure an ARN to use as the MFA device
     --duration=<time>, -d <time>     How long to create the session for
                                      [default: 43200]
+    --shell                          Launch a shell having the correct credentials
 '''
 
 
@@ -25,7 +30,10 @@ import docopt
 import jsonschema
 import textwrap
 import yaml
+from contextlib import contextmanager
 
+#import logging
+#boto3.set_stream_logger('', logging.DEBUG)
 
 CONFIG_FILE = os.path.join(
     os.path.expanduser('~'), '.aws-mfa-login'
@@ -40,9 +48,14 @@ CONFIG_SCHEMA = {
       'account':  {
         'type': 'object',
         'properties': {
-            'mfa_arn': {'type': 'string'}
+            'mfa_arn': {'type': 'string'},
+            'role_map': {
+                'type': 'object',
+                'additionalProperties': {'type': 'string'}
+            }
         }
-      }
+      },
+      'role_map':  { "$ref": "#/definitions/role_map" }
     },
     'type': 'object',
     'properties': {
@@ -50,13 +63,82 @@ CONFIG_SCHEMA = {
         'profiles' : {
            'type': 'object',
            'additionalProperties': { "$ref": "#/definitions/account" }
-        }
+        },
+        'role_map':  { "$ref": "#/definitions/role_map" }
    }
 }
 
+class EnvManager:
+    import pwd
+    import platform
+    import os
+    import subprocess
+
+    def __init__(self):
+        pass
+
+    def get_exports(self, keys):
+        creds = keys['Credentials']
+        access_key_id = creds['AccessKeyId']
+        secret_access_key = creds['SecretAccessKey']
+        session_token = creds['SessionToken']
+        expiration = creds['Expiration']
+
+        print(textwrap.dedent('''
+            Paste the following into your terminal:
+
+                export AWS_ACCESS_KEY_ID="{access}"
+                export AWS_SECRET_ACCESS_KEY="{secret}"
+                export AWS_SESSION_TOKEN="{token}"
+
+            These credentials will expire at {expire}.
+        '''.format(
+                access=access_key_id,
+                secret=secret_access_key,
+                token=session_token,
+                expire=expiration
+            )
+        ))
+
+    def _get_shell(self):
+        # should detect OS here and return correct shell, but for now assume bash works
+        return ['/bin/bash', '-i'], 'debian_chroot'
+
+    def start_shell(self, keys, sessionName):
+        creds = keys['Credentials']
+        access_key_id = creds['AccessKeyId']
+        secret_access_key = creds['SecretAccessKey']
+        session_token = creds['SessionToken']
+
+        env = os.environ.copy()
+
+        env['AWS_ACCESS_KEY_ID'] = access_key_id
+        env['AWS_SECRET_ACCESS_KEY'] = secret_access_key
+        env['AWS_SESSION_TOKEN'] = session_token
+
+        shellCmdArgs, promptVar = self._get_shell()
+        if promptVar in env:
+            env[promptVar] = ':'.join([env[promptVar],sessionName])
+        else:
+            env[promptVar] = sessionName
+
+        self.subprocess.run(shellCmdArgs,env=env)
+
+
 class AccountManager:
+
     def __init__(self, profile):
         self.profile = profile
+
+
+    @contextmanager
+    def persistConfig(self):
+        conf = self.get_config()
+        try:
+            yield conf
+        finally:
+            self.store_config(conf)
+
 
     def get_config(self):
         conf = None
@@ -81,16 +163,15 @@ class AccountManager:
 
 
     def set_mfa_arn(self, arn):
-        conf = self.get_config()
-        if self.profile != 'default':
-            if not 'profiles'  in conf:
-                conf['profiles'] = {}
-            if self.profile not in conf['profiles']:
-                conf['profiles'][self.profile] = {}
-            conf['profiles'][self.profile]['mfa_arn'] = arn
-        else:
-            conf['mfa_arn'] = arn
-        self.store_config(conf)
+        with self.persistConfig() as conf:
+           if self.profile != 'default':
+               if not 'profiles'  in conf:
+                   conf['profiles'] = {}
+               if self.profile not in conf['profiles']:
+                   conf['profiles'][self.profile] = {}
+               conf['profiles'][self.profile]['mfa_arn'] = arn
+           else:
+               conf['mfa_arn'] = arn
 
 
     def get_mfa_arn(self):
@@ -102,6 +183,31 @@ class AccountManager:
                 print('missing ARN for profile ', self.profile)
         return conf['mfa_arn']
 
+    def set_role_arn(self, nickname, arn):
+        with self.persistConfig() as conf:
+           if self.profile != 'default':
+               if not 'profiles'  in conf:
+                   conf['profiles'] = {}
+               if self.profile not in conf['profiles']:
+                   conf['profiles'][self.profile] = {}
+               if 'role_map' not in conf['profiles'][self.profile]:
+                   conf['profiles'][self.profile]['role_map'] = {}
+               conf['profiles'][self.profile]['role_map'][nickname] = arn
+           else:
+               conf['role_map'][nickname] = arn
+
+    def get_role_arn(self, nickname):
+        conf = self.get_config()
+        try:
+            if self.profile != 'default':
+                if self.profile in conf['profiles'] and nickname in  conf['profiles'][self.profile]['role_map']:
+                    return conf['profiles'][self.profile]['role_map'][nickname]
+                else:
+                    print('missing ARN for profile ', self.profile,' role ', nickname)
+            return conf['role_map'][nickname]
+        except:
+            return None
+
 
     def ensure_mfa_arn(self):
             mfa = self.get_mfa_arn()
@@ -110,9 +216,20 @@ class AccountManager:
                 return mfa
 
             mfa_arn = input('What is your MFA ARN?: ')
-            set_mfa_arn(mfa_arn)
+            self.set_mfa_arn(mfa_arn)
 
             return mfa_arn
+
+    def ensure_role_arn(self, nickname):
+            role = self.get_role_arn(nickname)
+
+            if role:
+                return role
+
+            role_arn = input('What is your role ARN for {}?: '.format(nickname))
+            self.set_role_arn(nickname, role_arn)
+
+            return role_arn
 
 
     def get_session_keys(self, mfa_arn, mfa_token, duration):
@@ -125,29 +242,17 @@ class AccountManager:
             TokenCode=mfa_token
         )
 
+    def get_role_keys(self, role_arn, nickname,duration):
+        if self.profile != 'default':
+           session = boto3.Session(profile_name=self.profile)
+        aws_client = session.client('sts')
+        return aws_client.assume_role(
+            RoleArn=role_arn,
+            RoleSessionName=nickname,
+            DurationSeconds=duration
+        )
 
-    def get_exports(self, keys):
-        creds = keys['Credentials']
-        access_key_id = creds['AccessKeyId']
-        secret_access_key = creds['SecretAccessKey']
-        session_token = creds['SessionToken']
-        expiration = creds['Expiration']
 
-        print(textwrap.dedent('''
-            Paste the following into your terminal:
-
-                export AWS_ACCESS_KEY_ID="{access}"
-                export AWS_SECRET_ACCESS_KEY="{secret}"
-                export AWS_SESSION_TOKEN="{token}"
-    
-            These credentials will expire at {expire}.
-        '''.format(
-                access=access_key_id,
-                secret=secret_access_key,
-                token=session_token,
-                expire=expiration
-            )
-        ))
 
 
 def main(args):
@@ -166,7 +271,26 @@ def main(args):
         duration = int(args.get('--duration'))
 
         keys = mgr.get_session_keys(mfa_arn, mfa_token, duration)
-        mgr.get_exports(keys)
+        envMgr = EnvManager()
+        if args.get('--shell'):
+            envMgr.start_shell(keys, profile)
+        else:
+            envMgr.get_exports(keys)
+
+    if args.get('add-role'):
+        mgr.set_role_arn(args.get('<nickname>'),args.get('<role_arn>'))
+
+    if args.get('assume-role'):
+        role_arn = mgr.ensure_role_arn(args.get('<nickname>'))
+
+        duration = int(args.get('--duration'))
+        nickname = args.get('<nickname>')
+        keys = mgr.get_role_keys(role_arn, nickname ,duration)
+        envMgr = EnvManager()
+        if args.get('--shell'):
+            envMgr.start_shell(keys, ':'.join([profile,nickname]))
+        else:
+            envMgr.get_exports(keys)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds  to aws-mfa:
 - an option select profile. (Eg, aws account)
  To do this we move all the functions into a class that knows about the profile.
   Migrates old conf files to a new format which knows about profiles (cleaner than trying to support the old format at the same time)

 - Ability to enter a role
 - Ability to set up a subshell with the profile/role in the command prompt (ubuntu only so far, but should be simple on other linux/macos)
Also the schema was confusing so I changed to migrate old conf files to a new format

I've written this rather quickly so there are probably bugs.

